### PR TITLE
Ensure files are closed after open

### DIFF
--- a/mikatools/__init__.py
+++ b/mikatools/__init__.py
@@ -105,7 +105,8 @@ def json_dump(data, file_path, sort_keys=True):
 	:type file_path: string
 	:type sort_keys: bool
 	"""
-	json.dump(data, codecs.open(file_path, "w", encoding="utf-8"),indent=4, sort_keys=sort_keys, ensure_ascii=False)
+	with codecs.open(file_path, "w", encoding="utf-8") as file_handle:
+		json.dump(data, file_handle ,indent=4, sort_keys=sort_keys, ensure_ascii=False)
 
 def json_load(file_path):
 	"""
@@ -115,7 +116,8 @@ def json_load(file_path):
 	:rtype: dict
 	:return: The JSON dictionary
 	"""
-	return json.load(codecs.open(file_path, "r", encoding="utf-8"))
+	with codecs.open(file_path, "r", encoding="utf-8") as file_handle:
+		return json.load(file_handle)
 
 def open_read(file_path):
 	"""


### PR DESCRIPTION
This patch simply extracts the `codecs.open` calls in `json_dump` and `json_load` to a `with .. as` statement, so that the opened files are automatically closed.

While Python does close all file handles eventually even without a context manager (or a manual call to `close`), it results in an annoying and unnecessary `ResourceWarning`s in the logs.

For example the following gets logged when using UralicNLP:
```
<snip>/mikatools/__init__.py:118: ResourceWarning: unclosed file <_io.BufferedReader name='<snip>/uralicNLP/models/eng/metadata.json'>
  return json.load(codecs.open(file_path, "r", encoding="utf-8"))
```
